### PR TITLE
Fixed compile error. Added block to case label.

### DIFF
--- a/lib/punity-tiled.h
+++ b/lib/punity-tiled.h
@@ -269,38 +269,40 @@ tiled_load_meta_(TiledLoader_ *L, int type, void *data, json_value *properties)
     switch (type)
     {
     case TiledType_Tile:
-        Tile *tile = (Tile*)data;
-        v = json_find_value(properties, "edges");
-        if (v && v->type == json_string)  {
-            for (char *it = v->string.ptr; *it; ++it) {
-                switch (*it)
-                {
-                case 'T': case 't':
-                    tile->flags |= Edge_Top;
-                    break;
-                case 'B': case 'b':
-                    tile->flags |= Edge_Bottom;
-                    break;
-                case 'L': case 'l':
-                    tile->flags |= Edge_Left;
-                    break;
-                case 'R': case 'r':
-                    tile->flags |= Edge_Right;
-                    break;
+        {
+            Tile *tile = (Tile*)data;
+            v = json_find_value(properties, "edges");
+            if (v && v->type == json_string)  {
+                for (char *it = v->string.ptr; *it; ++it) {
+                    switch (*it)
+                    {
+                    case 'T': case 't':
+                        tile->flags |= Edge_Top;
+                        break;
+                    case 'B': case 'b':
+                        tile->flags |= Edge_Bottom;
+                        break;
+                    case 'L': case 'l':
+                        tile->flags |= Edge_Left;
+                        break;
+                    case 'R': case 'r':
+                        tile->flags |= Edge_Right;
+                        break;
+                    }
                 }
-            }
 #ifdef TILEDTILE_DEFAULT_LAYER
-            if (tile->flags != 0) {
-                tile->layer = TILEDTILE_DEFAULT_LAYER;
-            }
+                if (tile->flags != 0) {
+                    tile->layer = TILEDTILE_DEFAULT_LAYER;
+                }
 #endif
-        }
+            }
 
-        v = json_find_value(properties, "layer");
-        if (v && v->type == json_integer) {
-            tile->layer = v->integer;
+            v = json_find_value(properties, "layer");
+            if (v && v->type == json_integer) {
+                tile->layer = v->integer;
+            }
+            break;
         }
-        break;
     }
 
     if (L->meta_callback) {


### PR DESCRIPTION
On mingw, a variable declaration in a case label needs to be in a separate block.

I added a block for the label.

```shell
-------------------------------------------------
- Compiler:      gcc
- Configuration: debug
- Runtime:       PUN_RUNTIME_WINDOWS
- Target C:      example-platformer
- Target RC:     example-platformer.rc
- Output:        bin\example-platformer.exe
-------------------------------------------------

Building resources...

Compiling...
Building debug...
In file included from ./lib/punity-tiled.h:139:0,
                 from example-platformer.c:19:
./lib/json.h: In function 'new_value':
./lib/json.h:258:42: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
                   (state, values_size + ((unsigned long) value->object.values), 0)) )
                                          ^
In file included from example-platformer.c:19:0:
./lib/punity-tiled.h: In function 'tiled_load_meta_':
./lib/punity-tiled.h:272:9: error: a label can only be part of a statement and a declaration is not a statement
         Tile *tile = (Tile*)data;
         ^~~~
```